### PR TITLE
ルーム参加時にルームIDの状態が保持されないのバグ修正 

### DIFF
--- a/src/features/games/room/components/RoomSelectForm.tsx
+++ b/src/features/games/room/components/RoomSelectForm.tsx
@@ -8,7 +8,7 @@ import { ROOM_MODES } from "../types";
 import { JoinRoomRequestType, useCreateRoomMutation, useJoinRoomMutation } from "../api";
 import { inviteIdState, roomModeState } from "../states/atoms";
 import { colors } from "@/assets/styles";
-import { useRecoilState } from "recoil";
+import { useSetRecoilState } from "recoil";
 
 const _RoomSelectForm= styled.div`
   height : 100%;
@@ -78,11 +78,7 @@ export const RoomSelectForm = ({ onSuccess }: RoomSelectFormProps) => {
   const createRoomMutation= useCreateRoomMutation();
   const joinRoomMutation  = useJoinRoomMutation();
 
-  const [ inviteId, setInviteId ]= useRecoilState( inviteIdState );
-
-  const handleInviteId= ( e: React.ChangeEvent<HTMLInputElement> ) => {
-    setInviteId( e.target.value );
-  };
+  const setInviteId= useSetRecoilState( inviteIdState );
 
   return (    
     <_RoomSelectForm>
@@ -111,6 +107,7 @@ export const RoomSelectForm = ({ onSuccess }: RoomSelectFormProps) => {
               <Form<JoinRoomRequestType, typeof RoomIdSchema>
                 onSubmit={ async({ inviteId }: JoinRoomRequestType ) => {
                   await joinRoomMutation.mutateAsync( inviteId )
+                  setInviteId( inviteId )
                   onSuccess()
                 }}
                 schema={RoomIdSchema}
@@ -123,10 +120,8 @@ export const RoomSelectForm = ({ onSuccess }: RoomSelectFormProps) => {
                       type='text'
                       size='medium'
                       error= { errors.inviteId }
-                      value={ inviteId }
                       placeholder='ルームIDを入力してください。'
                       registration= { register('inviteId') }
-                      onChange={ handleInviteId }
                       styles={ InputRoomIdStyle } 
                     />          
                     <$StartButton type='submit'>START</$StartButton>

--- a/src/features/games/standby/routes/StandBy.tsx
+++ b/src/features/games/standby/routes/StandBy.tsx
@@ -122,25 +122,23 @@ export const StandBy= () => {
 
   useEffect(() => {
     if( !roomInfoQuery?.data ) return;
+
     if( roomInfoQuery?.data?.started ) {
       navigate('../phase/attack-phase');
+    } else if( !roomInfoQuery?.data?.host && roomInfoQuery?.data?.opponentName === null ) {
+      exitRoomMutation.mutateAsync();
     };
-  }, [ navigate, roomInfoQuery?.data?.started ]);
+  }, [ navigate, roomInfoQuery?.data ]);
 
   if( authUserQuery.isLoading || roomInfoQuery.isLoading ) {
     return <Loading />
   };
 
-  if( !authUserQuery.data || !roomInfoQuery.data ) return null;
+  if( !authUserQuery?.data || !roomInfoQuery?.data ) return null;
 
-  if( !roomInfoQuery?.data?.host && roomInfoQuery?.data?.opponentName === null ) {
-    exitRoomMutation.mutateAsync();
-    navigate('../../');
-  };
-
-  const hostUser = roomInfoQuery?.data?.host  ? authUserQuery?.data.name : roomInfoQuery?.data.opponentName;
-  const guestUser= !roomInfoQuery?.data?.host ? authUserQuery?.data.name : roomInfoQuery?.data.opponentName;
-  const canStarted= roomInfoQuery?.data?.opponentName;
+  const hostUser = roomInfoQuery.data?.host  ? authUserQuery.data?.name : roomInfoQuery.data?.opponentName;
+  const guestUser= !roomInfoQuery.data?.host ? authUserQuery.data?.name : roomInfoQuery.data?.opponentName;
+  const canStarted= roomInfoQuery.data?.opponentName;
 
   return (
     <StandbyLayout>
@@ -170,7 +168,7 @@ export const StandBy= () => {
               />
             : <$OpponentLoader />
           }
-        { canStarted !==null && roomInfoQuery?.data.host
+        { canStarted !==null && roomInfoQuery.data?.host
           ? <$StartButton 
               type='button'
               onClick={ async() => await startGameMutation.mutateAsync() }


### PR DESCRIPTION
## Issueへのリンク
<!-- resolve: #Issue番号 -->
resolve: #91 

### 概要
ルーム参加時にルームIDの状態が保持されないのバグ修正

### 作業内容

- [x] recoilで入力したルームIDの状態を管理して、待機画面遷移時に表示する

## 動作確認
<!-- 必要であれば実施して記載 -->
なし

## レビュワーへの参考情報
<!-- 実装上の懸念点やレビューにおける注意点などがもしあれば記載 -->
なし

## チェックリスト
- [x] タイトルを設定している
- [x] Issue へのリンクを設定している
- [x] Assignees を設定している
- [x] Labels を設定している

<!-- Create pull requestを押す前にPreviewを確認すること -->
