### PR TITLE
アタックフェーズ、バトルフェーズのコード部分をreadOnlyにする

### DIFF
--- a/src/features/games/codeController/components/EditArea.tsx
+++ b/src/features/games/codeController/components/EditArea.tsx
@@ -9,9 +9,10 @@ import { codeState }   from '../states';
 
 type EditAreaProps= {
   code:string;
+  canWrite?: boolean;
 };
 
-export const EditArea= ({ code }: EditAreaProps) => {
+export const EditArea= ({ code, canWrite }: EditAreaProps) => {
   const setCode =useSetRecoilState( codeState );
   const handleCode= ( value: string ) => {
     setCode(value);
@@ -24,6 +25,7 @@ export const EditArea= ({ code }: EditAreaProps) => {
         theme     = { vscodeDark }
         basicSetup= { EditorSetup }
         extensions= {[ color,php() ]}
+        readOnly  = { !canWrite }
       />
   );
 };

--- a/src/features/games/phases/routes/AttackPhase.tsx
+++ b/src/features/games/phases/routes/AttackPhase.tsx
@@ -43,7 +43,12 @@ export const AttackPhase= () => {
         }
         body={
           isShowCode
-          ? <EditorWrapper><EditArea code={challengeQuery?.data?.code} /></EditorWrapper>
+          ? <EditorWrapper>
+              <EditArea 
+                code={ challengeQuery?.data?.code }
+                canWrite={ false }
+              />
+            </EditorWrapper>
           : <ChoicesWrapper />
         }
         foot={

--- a/src/features/games/phases/routes/BattlePhase.tsx
+++ b/src/features/games/phases/routes/BattlePhase.tsx
@@ -34,7 +34,13 @@ export const BattlePhase= () => {
     >
       <PhaseContentsWrapper
         head={ <PhaseHeadContents phase={ PHASE.BATTLE_PHASE } title={'脆弱性を見つけ出して攻撃してください。'} /> }
-        body={ <EditorWrapper><EditArea code={revisionCodeQuery?.data?.code} /></EditorWrapper> }
+        body={ 
+          <EditorWrapper>
+            <EditArea 
+              code={revisionCodeQuery?.data?.code}
+              canWrite={ false }
+            />
+          </EditorWrapper> }
         foot={
           <PhaseContentForm
             id={ 'attack-phase' }


### PR DESCRIPTION
## Issueへのリンク
<!-- resolve: #Issue番号 -->
resolve: #105 

### 概要
アタックフェーズ、バトルフェーズのコード部分をreadOnlyにする

### 作業内容

- [x] アタックフェーズ、バトルフェーズのcodemirrorの設定をreadOnlyにする
- [x] readOnlyを適用するpropsの追加

## 動作確認
<!-- 必要であれば実施して記載 -->
なし

## レビュワーへの参考情報
<!-- 実装上の懸念点やレビューにおける注意点などがもしあれば記載 -->
なし

## チェックリスト
- [ ] タイトルを設定している
- [ ] Issue へのリンクを設定している
- [ ] Assignees を設定している
- [ ] Labels を設定している

<!-- Create pull requestを押す前にPreviewを確認すること -->
